### PR TITLE
Add createdAt to stdout

### DIFF
--- a/lib/build-manager.js
+++ b/lib/build-manager.js
@@ -127,8 +127,7 @@ function createBundler(browserify, file) {
     })
     function next(err) {
       if (err) return task.emit('exit', err)
-      const elapsed = ((Date.now() - ts) / 1000).toFixed(2)
-      process.stdout.write(`>> created ${file} over ${elapsed}s\n`)
+      outputBuildStatus(`created ${file} over`, ts);
       task.emit('exit')
     }
     return task
@@ -150,14 +149,25 @@ function createExecutor(command) {
         err.quiet = true
         return task.emit('exit', err)
       }
-      const elapsed = ((Date.now() - ts) / 1000).toFixed(2)
-      process.stdout.write(`>> completed "${command}" in ${elapsed}s\n`)
+      outputBuildStatus(`completed ${command} in`, ts);
       task.emit('exit')
     })
     proc.stdout.pipe(process.stdout)
     proc.stderr.pipe(process.stderr)
     return task
   }
+}
+
+/**
+ *
+ * @param {string} operation
+ * @param {string} ts
+ */
+function outputBuildStatus(operation, ts) {
+  const now = new Date()
+  const elapsed = ((Date.now() - ts) / 1000).toFixed(2)
+  const createdAt = ("0"+(now.getMonth()+1)).slice(-2) + "-" + ("0" + now.getDate()).slice(-2) + "-" + now.getFullYear() + " " + ("0" + now.getHours()).slice(-2) + ":" + ("0" + now.getMinutes()).slice(-2) + ":" + ("0" + now.getSeconds()).slice(-2);
+  process.stdout.write(`${createdAt} >> ${operation} ${elapsed}s\n`)
 }
 
 module.exports = createBuildManager

--- a/lib/build-manager.js
+++ b/lib/build-manager.js
@@ -164,9 +164,8 @@ function createExecutor(command) {
  * @param {string} ts
  */
 function outputBuildStatus(operation, ts) {
-  const now = new Date()
   const elapsed = ((Date.now() - ts) / 1000).toFixed(2)
-  const createdAt = ("0"+(now.getMonth()+1)).slice(-2) + "-" + ("0" + now.getDate()).slice(-2) + "-" + now.getFullYear() + " " + ("0" + now.getHours()).slice(-2) + ":" + ("0" + now.getMinutes()).slice(-2) + ":" + ("0" + now.getSeconds()).slice(-2);
+  const createdAt = new Date().toTimeString().substr(0, 8)
   process.stdout.write(`${createdAt} >> ${operation} ${elapsed}s\n`)
 }
 


### PR DESCRIPTION
Add **createdAt** to the stdout so that a user can see when the build completed. 

`mm-dd-yyyy hh:mm:ss`

<img width="525" alt="screen shot 2017-01-31 at 09 58 53" src="https://cloud.githubusercontent.com/assets/17713805/22477741/1dcda86e-e79c-11e6-914d-ad60d26fe1e9.png">
